### PR TITLE
Added custom dimension 1 support to the Event class

### DIFF
--- a/google_measurement_protocol/__init__.py
+++ b/google_measurement_protocol/__init__.py
@@ -86,10 +86,10 @@ class PageView(
         return payload
 
 
-class Event(Requestable, namedtuple('Event', 'category action label value')):
+class Event(Requestable, namedtuple('Event', 'category action label value custom1')):
 
-    def __new__(cls, category, action, label=None, value=None):
-        return super(Event, cls).__new__(cls, category, action, label, value)
+    def __new__(cls, category, action, label=None, value=None, custom1=None):
+        return super(Event, cls).__new__(cls, category, action, label, value, custom1)
 
     def get_payload(self):
         payload = {
@@ -100,6 +100,8 @@ class Event(Requestable, namedtuple('Event', 'category action label value')):
             payload['el'] = self.label
         if self.value:
             payload['ev'] = str(int(self.value))
+        if self.custom1:
+            payload['cd1'] = str(int(self.custom1))
         return payload
 
 


### PR DESCRIPTION
Events can be used to submit optional custom dimension values. I've added an optional `custom1` dimension to the Event payload to support this. Since you can have a number of custom dimensions, I am planning to enhance this to use a list, but wanted to get this PR in first. Feedback and suggestions welcome!

PS: I love this library, so thanks so much for making it!