### PR TITLE
Add link to Github on PyPI

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -15,6 +15,7 @@ CLASSIFIERS = [
 setup(
     name='google-measurement-protocol',
     author='Mirumee Software',
+    url='https://github.com/mirumee/google-measurement-protocol',
     author_email='hello@mirumee.com',
     description=(
         'A Python implementation of Google Analytics Measurement Protocol'),


### PR DESCRIPTION
Currently the [PyPI page](https://pypi.org/project/google-measurement-protocol/) doesn't reflect the origin of this package, which is (presumably) this repo.